### PR TITLE
some changes

### DIFF
--- a/packages/runtime-tools-process-dev-ui-webapp/env/index.js
+++ b/packages/runtime-tools-process-dev-ui-webapp/env/index.js
@@ -25,6 +25,15 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
       default: "http://localhost:4000/graphql",
       description: "URL for the Data Index service",
     },
+    RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__kogitoAppUrl: {
+      default: null,
+      description:
+        "URL to a remote Kogito Application. If set, the devUI will use the url to fetch OpenApi doc instead of using the mock value from the server.js.",
+    },
+    RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__openApiDocPath: {
+      default: "/q/openapi.json",
+      description: "Relative path to the OpenApi document to load the Process Definitions.",
+    },
     RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__host: {
       default: "localhost",
       description: "Webpack server hostname",
@@ -38,6 +47,8 @@ module.exports = composeEnv([require("@kie-tools/root-env/env")], {
     return {
       runtimeToolsProcessDevUIWebapp: {
         kogitoDataIndexUrl: getOrDefault(this.vars.RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__kogitoDataIndexUrl),
+        kogitoAppUrl: getOrDefault(this.vars.RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__kogitoAppUrl),
+        openApiPath: getOrDefault(this.vars.RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__openApiDocPath),
         host: getOrDefault(this.vars.RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__host),
         port: getOrDefault(this.vars.RUNTIME_TOOLS_PROCESS_DEV_UI_WEBAPP__port),
       },

--- a/packages/runtime-tools-process-dev-ui-webapp/resources/index.html
+++ b/packages/runtime-tools-process-dev-ui-webapp/resources/index.html
@@ -51,9 +51,8 @@
           { id: "saravana", groups: [] },
           { id: "john", groups: [] },
         ],
-        page: "JobsManagement",
+        page: "Processes",
         devUIUrl: "http://localhost:9027",
-        openApiPath: "q/openapi.json",
         customLabels: {
           singularProcessLabel: "Process",
           pluralProcessLabel: "Process",

--- a/packages/runtime-tools-process-dev-ui-webapp/src/api/RuntimeToolsDevUIEnvelopeApi.ts
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/api/RuntimeToolsDevUIEnvelopeApi.ts
@@ -36,6 +36,7 @@ export interface User {
 export interface RuntimeToolsDevUIInitArgs {
   users?: User[];
   dataIndexUrl: string;
+  remoteKogitoAppUrl?: string;
   page: string;
   devUIUrl: string;
   openApiPath: string;

--- a/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListContextProvider.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListContextProvider.tsx
@@ -29,7 +29,10 @@ const ProcessDefinitionListContextProvider: React.FC<ProcessDefinitionListContex
   const runtimeToolsApi: DevUIAppContext = useDevUIAppContext();
 
   const gatewayApiImpl = useMemo(() => {
-    return new ProcessDefinitionListGatewayApiImpl(runtimeToolsApi.getDevUIUrl(), runtimeToolsApi.getOpenApiPath());
+    return new ProcessDefinitionListGatewayApiImpl(
+      runtimeToolsApi.getRemoteKogitoAppUrl() ?? runtimeToolsApi.getDevUIUrl(),
+      runtimeToolsApi.getOpenApiPath()
+    );
   }, []);
 
   return (

--- a/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListGatewayApi.ts
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/channel/ProcessDefinitionList/ProcessDefinitionListGatewayApi.ts
@@ -46,21 +46,21 @@ export class ProcessDefinitionListGatewayApiImpl implements ProcessDefinitionLis
   private readonly onOpenProcessListeners: OnOpenProcessFormListener[] = [];
   private readonly onOpenTriggerCloudEventListeners: OnOpenTriggerCloudEventListener[] = [];
 
-  private readonly devUIUrl: string;
+  private readonly kogitoAppUrl: string;
   private readonly openApiPath: string;
-  private processDefinitonFilter: string[] = [];
+  private processDefinitionFilter: string[] = [];
 
   constructor(url: string, path: string) {
-    this.devUIUrl = url;
+    this.kogitoAppUrl = url;
     this.openApiPath = path;
   }
 
   getProcessDefinitionFilter(): Promise<string[]> {
-    return Promise.resolve(this.processDefinitonFilter);
+    return Promise.resolve(this.processDefinitionFilter);
   }
 
   setProcessDefinitionFilter(filter: string[]): Promise<void> {
-    this.processDefinitonFilter = filter;
+    this.processDefinitionFilter = filter;
     return Promise.resolve();
   }
 
@@ -100,7 +100,7 @@ export class ProcessDefinitionListGatewayApiImpl implements ProcessDefinitionLis
   }
 
   getProcessDefinitionsQuery(): Promise<ProcessDefinition[]> {
-    return getProcessDefinitionList(this.devUIUrl, this.openApiPath);
+    return getProcessDefinitionList(this.kogitoAppUrl, this.openApiPath);
   }
 
   openTriggerCloudEvent(): void {

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUILayout/DevUILayout.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/DevUILayout/DevUILayout.tsx
@@ -44,6 +44,7 @@ interface IOwnProps {
   children: React.ReactElement;
   devUIUrl: string;
   openApiPath: string;
+  remoteKogitoAppUrl: string;
   availablePages?: string[];
   customLabels: CustomLabels;
   omittedProcessTimelineEvents?: string[];
@@ -56,6 +57,7 @@ const DevUILayout: React.FC<IOwnProps> = ({
   users,
   devUIUrl,
   openApiPath,
+  remoteKogitoAppUrl,
   availablePages,
   customLabels,
   omittedProcessTimelineEvents,
@@ -76,6 +78,7 @@ const DevUILayout: React.FC<IOwnProps> = ({
         users={users}
         devUIUrl={devUIUrl}
         openApiPath={openApiPath}
+        remoteKogitoAppUrl={remoteKogitoAppUrl}
         isProcessEnabled={isProcessEnabled}
         availablePages={availablePages}
         customLabels={customLabels}

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/RuntimeTools/RuntimeTools.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/DevUI/RuntimeTools/RuntimeTools.tsx
@@ -36,6 +36,7 @@ interface IOwnProps {
   navigate: string;
   devUIUrl: string;
   openApiPath: string;
+  remoteKogitoAppUrl: string;
   availablePages: string[];
   customLabels: CustomLabels;
   omittedProcessTimelineEvents: string[];
@@ -48,6 +49,7 @@ const RuntimeTools: React.FC<IOwnProps> = ({
   navigate,
   devUIUrl,
   openApiPath,
+  remoteKogitoAppUrl,
   isProcessEnabled,
   availablePages,
   customLabels,
@@ -69,6 +71,7 @@ const RuntimeTools: React.FC<IOwnProps> = ({
           users={users}
           devUIUrl={devUIUrl}
           openApiPath={openApiPath}
+          remoteKogitoAppUrl={remoteKogitoAppUrl}
           isProcessEnabled={isProcessEnabled}
           availablePages={availablePages}
           customLabels={customLabels}
@@ -94,6 +97,7 @@ const RuntimeTools: React.FC<IOwnProps> = ({
       users={users}
       devUIUrl={devUIUrl}
       openApiPath={openApiPath}
+      remoteKogitoAppUrl={remoteKogitoAppUrl}
       isProcessEnabled={isProcessEnabled}
       availablePages={availablePages}
       customLabels={customLabels}

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/TaskInboxContainer/TaskInboxContainer.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/containers/TaskInboxContainer/TaskInboxContainer.tsx
@@ -24,7 +24,7 @@ import {
   useTaskInboxGatewayApi,
   TaskInboxGatewayApi,
 } from "@kie-tools/runtime-tools-process-webapp-components/dist/TaskInbox";
-import { EmbeddedTaskInbox, TaskInboxApi } from "@kie-tools/runtime-tools-process-enveloped-components/src/taskInbox";
+import { EmbeddedTaskInbox, TaskInboxApi } from "@kie-tools/runtime-tools-process-enveloped-components/dist/taskInbox";
 import { UserTaskInstance } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
 import { getActiveTaskStates, getAllTaskStates } from "@kie-tools/runtime-tools-process-webapp-components/dist/utils";
 
@@ -43,6 +43,7 @@ const TaskInboxContainer: React.FC<OUIAProps> = ({ ouiaId, ouiaSafe }) => {
 
     const unsubscribeUserChange = appContext.onUserChange({
       onUserChange(user) {
+        alert(`switch user ${user.id}`);
         taskInboxApiRef.current.taskInbox__notify(user.id);
       },
     });

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/DevUIAppContext.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/DevUIAppContext.tsx
@@ -29,6 +29,7 @@ export interface DevUIAppContext {
   onUserChange(listener: UserChangeListener): UnSubscribeHandler;
   getDevUIUrl(): string;
   getOpenApiPath(): string;
+  getRemoteKogitoAppUrl(): string;
   availablePages?: string[];
   customLabels: CustomLabels;
   omittedProcessTimelineEvents: string[];
@@ -47,6 +48,7 @@ export type DevUIAppContextArgs = {
   users?: User[];
   devUIUrl: string;
   openApiPath: string;
+  remoteKogitoAppUrl: string;
   isProcessEnabled: boolean;
   availablePages?: string[];
   customLabels?: CustomLabels;
@@ -70,6 +72,10 @@ export class DevUIAppContextImpl implements DevUIAppContext {
 
   getOpenApiPath(): string {
     return this.args.openApiPath;
+  }
+
+  getRemoteKogitoAppUrl(): string {
+    return this.args.remoteKogitoAppUrl;
   }
 
   getCurrentUser(): User {

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/DevUIAppContextProvider.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/DevUIAppContextProvider.tsx
@@ -26,6 +26,7 @@ interface IOwnProps {
   users: User[];
   devUIUrl: string;
   openApiPath: string;
+  remoteKogitoAppUrl: string;
   isProcessEnabled: boolean;
   availablePages: string[];
   customLabels: CustomLabels;
@@ -37,6 +38,7 @@ const DevUIAppContextProvider: React.FC<IOwnProps> = ({
   users,
   devUIUrl,
   openApiPath,
+  remoteKogitoAppUrl,
   isProcessEnabled,
   availablePages,
   customLabels,
@@ -51,6 +53,7 @@ const DevUIAppContextProvider: React.FC<IOwnProps> = ({
           users,
           devUIUrl,
           openApiPath,
+          remoteKogitoAppUrl,
           isProcessEnabled,
           availablePages,
           customLabels,

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/TaskInboxContextProvider.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/contexts/TaskInboxContextProvider.tsx
@@ -35,7 +35,7 @@ export const TaskInboxContextProvider: React.FC<IOwnProps> = ({ apolloClient, ch
 
   return (
     <TaskInboxContext.Provider
-      value={new TaskInboxGatewayApiImpl(appContext.getCurrentUser(), new GraphQLTaskInboxQueries(apolloClient))}
+      value={new TaskInboxGatewayApiImpl(new GraphQLTaskInboxQueries(apolloClient), () => appContext.getCurrentUser())}
     >
       {children}
     </TaskInboxContext.Provider>

--- a/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/TaskDetailsPage/TaskDetailsPage.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/components/pages/TaskDetailsPage/TaskDetailsPage.tsx
@@ -55,7 +55,7 @@ import {
   KogitoEmptyState,
   KogitoEmptyStateType,
 } from "@kie-tools/runtime-tools-components/dist/components/KogitoEmptyState";
-import { EmbeddedTaskDetails, TaskState } from "@kie-tools/runtime-tools-process-enveloped-components/src/taskDetails";
+import { EmbeddedTaskDetails, TaskState } from "@kie-tools/runtime-tools-process-enveloped-components/dist/taskDetails";
 import { PageTitle } from "@kie-tools/runtime-tools-components/dist/components/PageTitle";
 
 interface Props {

--- a/packages/runtime-tools-process-dev-ui-webapp/src/envelope/RuntimeToolsDevUIEnvelopeApiImpl.ts
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/envelope/RuntimeToolsDevUIEnvelopeApiImpl.ts
@@ -63,6 +63,7 @@ export class RuntimeToolsDevUIEnvelopeApiImpl implements RuntimeToolsDevUIEnvelo
     this.view().navigateTo(initArgs.page);
     this.view().setDevUIUrl && this.view().setDevUIUrl(initArgs.devUIUrl);
     this.view().setOpenApiPath && this.view().setOpenApiPath(initArgs.openApiPath);
+    this.view().setRemoteKogitoAppUrl && this.view().setRemoteKogitoAppUrl(initArgs.remoteKogitoAppUrl);
     this.view().setAvailablePages && this.view().setAvailablePages(initArgs.availablePages);
     this.view().setCustomLabels && this.view().setCustomLabels(initArgs.customLabels);
     this.view().setOmittedProcessTimelineEvents &&

--- a/packages/runtime-tools-process-dev-ui-webapp/src/envelope/RuntimeToolsDevUIEnvelopeView.tsx
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/envelope/RuntimeToolsDevUIEnvelopeView.tsx
@@ -27,6 +27,7 @@ import { DiagramPreviewSize } from "@kie-tools/runtime-tools-process-enveloped-c
 export const RuntimeToolsDevUIEnvelopeView = React.forwardRef<RuntimeToolsDevUIEnvelopeViewApi>(
   (props, forwardingRef) => {
     const [dataIndexUrl, setDataIndexUrl] = React.useState("");
+    const [remoteKogitoAppUrl, setRemoteKogitoAppUrl] = React.useState("");
     const [DevUiUsers, setDevUiUsers] = React.useState<User[]>([]);
     const [navigate, setNavigate] = React.useState<string>("");
     const [devUIUrl, setDevUIUrl] = React.useState<string>("");
@@ -43,6 +44,9 @@ export const RuntimeToolsDevUIEnvelopeView = React.forwardRef<RuntimeToolsDevUIE
         return {
           setDataIndexUrl: (dataIndexUrl) => {
             setDataIndexUrl(dataIndexUrl);
+          },
+          setRemoteKogitoAppUrl: (remoteKogitoAppUrl) => {
+            setRemoteKogitoAppUrl(remoteKogitoAppUrl);
           },
           setUsers: (users) => {
             setDevUiUsers(users);
@@ -89,6 +93,7 @@ export const RuntimeToolsDevUIEnvelopeView = React.forwardRef<RuntimeToolsDevUIE
             customLabels={customLabels}
             omittedProcessTimelineEvents={omittedProcessTimelineEvents}
             diagramPreviewSize={diagramPreviewSize}
+            remoteKogitoAppUrl={remoteKogitoAppUrl}
           />
         )}
       </>

--- a/packages/runtime-tools-process-dev-ui-webapp/src/envelope/RuntimeToolsDevUIEnvelopeViewApi.ts
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/envelope/RuntimeToolsDevUIEnvelopeViewApi.ts
@@ -22,6 +22,7 @@ import { CustomLabels } from "../api/CustomLabels";
 
 export interface RuntimeToolsDevUIEnvelopeViewApi {
   setDataIndexUrl: (dataIndexUrl: string) => void;
+  setRemoteKogitoAppUrl: (remoteKogitoAppUrl: string) => void;
   setUsers: (users: User[]) => void;
   navigateTo: (page: string) => void;
   setDevUIUrl: (url: string) => void;

--- a/packages/runtime-tools-process-dev-ui-webapp/src/standalone/standalone.ts
+++ b/packages/runtime-tools-process-dev-ui-webapp/src/standalone/standalone.ts
@@ -18,7 +18,7 @@
  */
 import devUIEnvelopeIndex from "!!raw-loader!../../resources/iframe.html";
 import { EnvelopeServer } from "@kie-tools-core/envelope-bus/dist/channel";
-import { RuntimeToolsDevUIChannelApi, RuntimeToolsDevUIEnvelopeApi, User } from "../api";
+import { RuntimeToolsDevUIChannelApi, RuntimeToolsDevUIEnvelopeApi, RuntimeToolsDevUIInitArgs, User } from "../api";
 import { RuntimeToolsDevUIChannelApiImpl } from "../standalone/RuntimeToolsDevUIChannelApiImpl";
 import { CustomLabels } from "../api/CustomLabels";
 import { DiagramPreviewSize } from "@kie-tools/runtime-tools-process-enveloped-components/dist/processDetails";
@@ -34,7 +34,8 @@ export interface Consoles {
     dataIndexUrl?: string;
     page: string;
     devUIUrl: string;
-    openApiPath: string;
+    remoteKogitoAppUrl?: string;
+    openApiPath?: string;
     origin?: string;
     availablePages?: string[];
     customLabels?: CustomLabels;
@@ -51,6 +52,7 @@ const createEnvelopeServer = (
   page: string,
   devUIUrl: string,
   openApiPath: string,
+  remoteKogitoAppUrl: string,
   customLabels: CustomLabels,
   diagramPreviewSize?: DiagramPreviewSize,
   origin?: string,
@@ -58,6 +60,7 @@ const createEnvelopeServer = (
   omittedProcessTimelineEvents?: string[]
 ) => {
   const defaultOrigin = window.location.protocol === "file:" ? "*" : window.location.origin;
+
   return new EnvelopeServer<RuntimeToolsDevUIChannelApi, RuntimeToolsDevUIEnvelopeApi>(
     {
       postMessage: (message) => iframe.contentWindow?.postMessage(message, origin ?? defaultOrigin),
@@ -80,6 +83,7 @@ const createEnvelopeServer = (
           availablePages,
           omittedProcessTimelineEvents,
           diagramPreviewSize,
+          remoteKogitoAppUrl,
         }
       );
     }
@@ -111,9 +115,10 @@ export function open(args: {
   isDataIndexAvailable: boolean;
   users: User[];
   dataIndexUrl?: string;
+  remoteKogitoAppUrl?: string;
   page: string;
   devUIUrl: string;
-  openApiPath: string;
+  openApiPath?: string;
   origin?: string;
   availablePages?: string[];
   customLabels?: CustomLabels;
@@ -134,7 +139,8 @@ export function open(args: {
     args.dataIndexUrl ?? process.env.KOGITO_DATAINDEX_HTTP_URL,
     args.page,
     args.devUIUrl,
-    args.openApiPath,
+    args.openApiPath ?? process.env.KOGITO_OPENAPI_PATH,
+    args.remoteKogitoAppUrl ?? process.env.KOGITO_REMOTE_KOGITO_APP_URL,
     args.customLabels ?? {
       singularProcessLabel: "Process",
       pluralProcessLabel: "Processes",

--- a/packages/runtime-tools-process-dev-ui-webapp/webpack.config.js
+++ b/packages/runtime-tools-process-dev-ui-webapp/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = async (env) => {
       },
       proxy: [
         {
-          context: ["/svg", "/forms"],
+          context: ["/svg", "/forms", "/q", "/hiring/schema"],
           target: "http://localhost:4000",
           secure: false,
           changeOrigin: true,
@@ -67,6 +67,8 @@ module.exports = async (env) => {
         KOGITO_APP_VERSION: "DEV",
         KOGITO_APP_NAME: "Runtime tools dev-ui",
         KOGITO_DATAINDEX_HTTP_URL: dataIndexURL,
+        KOGITO_REMOTE_KOGITO_APP_URL: buildEnv.runtimeToolsProcessDevUIWebapp.kogitoAppUrl,
+        KOGITO_OPENAPI_PATH: buildEnv.runtimeToolsProcessDevUIWebapp.openApiPath,
       }),
       new CopyPlugin({
         patterns: [

--- a/packages/runtime-tools-process-gateway-api/src/gatewayApi/apis.tsx
+++ b/packages/runtime-tools-process-gateway-api/src/gatewayApi/apis.tsx
@@ -530,9 +530,9 @@ export const createProcessDefinitionList = (processDefinitionObjs: any, url: str
   return processDefinitionList;
 };
 
-export const getProcessDefinitionList = (devUIUrl: string, openApiPath: string): Promise<ProcessDefinition[]> => {
+export const getProcessDefinitionList = (kogitoAppUrl: string, openApiPath: string): Promise<ProcessDefinition[]> => {
   return new Promise((resolve, reject) => {
-    SwaggerParser.parse(`${devUIUrl}/${openApiPath}`)
+    SwaggerParser.parse(`${kogitoAppUrl}/${openApiPath.replace(/^\//, "")}`)
       .then((response) => {
         const processDefinitionObjs: any = [];
         const paths = response.paths;
@@ -547,7 +547,7 @@ export const getProcessDefinitionList = (devUIUrl: string, openApiPath: string):
               processDefinitionObjs.push({ [url]: paths[url] });
             }
           });
-        resolve(createProcessDefinitionList(processDefinitionObjs, devUIUrl));
+        resolve(createProcessDefinitionList(processDefinitionObjs, kogitoAppUrl));
       })
       .catch((err) => reject(err));
   });

--- a/packages/runtime-tools-process-webapp-components/src/TaskInbox/TaskInboxContextProvider.tsx
+++ b/packages/runtime-tools-process-webapp-components/src/TaskInbox/TaskInboxContextProvider.tsx
@@ -33,7 +33,7 @@ export const TaskInboxContextProvider: React.FC<IOwnProps> = ({ apolloClient, ch
 
   return (
     <TaskInboxContext.Provider
-      value={new TaskInboxGatewayApiImpl(appContext.getCurrentUser(), new GraphQLTaskInboxQueries(apolloClient))}
+      value={new TaskInboxGatewayApiImpl(new GraphQLTaskInboxQueries(apolloClient), () => appContext.getCurrentUser())}
     >
       {children}
     </TaskInboxContext.Provider>

--- a/packages/runtime-tools-process-webapp-components/src/TaskInbox/TaskInboxGatewayApi.ts
+++ b/packages/runtime-tools-process-webapp-components/src/TaskInbox/TaskInboxGatewayApi.ts
@@ -49,14 +49,14 @@ export interface UnSubscribeHandler {
 
 export class TaskInboxGatewayApiImpl implements TaskInboxGatewayApi {
   private readonly listeners: OnOpenTaskListener[] = [];
-  private readonly user: User;
+  private getCurrentUser: () => User;
   private readonly queries: TaskInboxQueries;
   private _taskInboxState: TaskInboxState;
   private activeTask: UserTaskInstance | null;
 
-  constructor(user: User, queries: TaskInboxQueries) {
-    this.user = user;
+  constructor(queries: TaskInboxQueries, getCurrentUser: () => User) {
     this.queries = queries;
+    this.getCurrentUser = getCurrentUser;
   }
 
   get taskInboxState(): TaskInboxState {
@@ -99,7 +99,7 @@ export class TaskInboxGatewayApiImpl implements TaskInboxGatewayApi {
   query(offset: number, limit: number): Promise<UserTaskInstance[]> {
     return new Promise<UserTaskInstance[]>((resolve, reject) => {
       this.queries
-        .getUserTasks(this.user, offset, limit, this._taskInboxState.filters, this._taskInboxState.sortBy)
+        .getUserTasks(this.getCurrentUser(), offset, limit, this._taskInboxState.filters, this._taskInboxState.sortBy)
         .then((value) => {
           this._taskInboxState.currentPage = { offset, limit };
           resolve(value);

--- a/packages/runtime-tools-task-console-webapp/src/components/pages/TaskInboxPage/container/TaskInboxContainer/TaskInboxContainer.tsx
+++ b/packages/runtime-tools-task-console-webapp/src/components/pages/TaskInboxPage/container/TaskInboxContainer/TaskInboxContainer.tsx
@@ -23,7 +23,7 @@ import {
   TaskInboxGatewayApi,
   useTaskInboxGatewayApi,
 } from "@kie-tools/runtime-tools-process-webapp-components/dist/TaskInbox";
-import { EmbeddedTaskInbox } from "@kie-tools/runtime-tools-process-enveloped-components/src/taskInbox";
+import { EmbeddedTaskInbox } from "@kie-tools/runtime-tools-process-enveloped-components/dist/taskInbox";
 import { getActiveTaskStates, getAllTaskStates } from "@kie-tools/runtime-tools-process-webapp-components/dist/utils";
 import { UserTaskInstance } from "@kie-tools/runtime-tools-process-gateway-api/dist/types";
 


### PR DESCRIPTION
* Adding extra envs to allow the dev ui connect to a remote app to get the list of process definitions
* Restored the `getCurrentUser` to get the user from context on every request. This is required to enable impersonation in DevUI